### PR TITLE
feat: add useMousePosition

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -53,7 +53,22 @@ module.exports = {
     editLinks: true,
     sidebarDepth: 2,
     sidebar: {
-      '/guide/': ['', 'battery', 'clipboard', 'device-light', 'device-motion', 'device-orientation', 'fullscreen', 'geolocation', 'intersection-observer', 'network', 'script', 'scroll-position', 'window-size'],
+      '/guide/': [
+        '',
+        'battery',
+        'clipboard',
+        'device-light',
+        'device-motion',
+        'device-orientation',
+        'fullscreen',
+        'geolocation',
+        'intersection-observer',
+        'mouse-position',
+        'network',
+        'script',
+        'scroll-position',
+        'window-size'
+      ],
       '/examples/': []
     },
     locales: {

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ npm install @vue/composition-api vue-use-web
 - [Full-screen](./guide/fullscreen.md).
 - [Geo-location API](./guide/geolocation.md).
 - [Intersection Observer](./guide/intersection-observer.md).
+- [Mouse Position](./guide/mouse-position.md)
 - [Network Information API](./guide/network.md).
 - [Script](./guide/script.md).
 - [Window Scroll Position](./guide/scroll-position.md).

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -29,6 +29,7 @@ These are the currently implemented Web APIs and the planned ones.
 - [Full-screen](./guide/fullscreen.md).
 - [Geo-location API](./guide/geolocation.md).
 - [Intersection Observer](./guide/intersection-observer.md).
+- [Mouse Position](./guide/mouse-position.md)
 - [Network Information API](./guide/network.md).
 - [Script](./guide/script.md).
 - [Window Scroll Position](./guide/scroll-position.md).

--- a/docs/guide/mouse-position.md
+++ b/docs/guide/mouse-position.md
@@ -1,0 +1,55 @@
+# Mouse Position
+
+This API provides access to the `x` and `y` of the mouse cursor position.
+
+## State
+
+The `useMousePosition` function exposes the following reactive state:
+
+```js
+import { useMousePosition } from 'vue-use-web';
+
+const { x, y } = useMousePosition();
+```
+
+| State | Type     | Description                                 |
+| ----- | -------- | ------------------------------------------- |
+| x     | `Number` | The mouse cursor position along the x-axis. |
+| y     | `Number` | The mouse cursor position along the y-axis. |
+
+:::tip Note!
+By default the updates the state are throttled by 100ms to keep things snappy but you can configure that.
+:::
+
+## Config
+
+`useMousePosition` function takes an options object as an optional parameter.
+
+```js
+import { useMousePosition } from 'vue-use-web';
+
+const { x, y } = useMousePosition();
+```
+
+## Example
+
+```vue
+<template>
+  <div>x: {{ x }} y: {{ y }}</div>
+</template>
+
+<script>
+// import { ref } from "@vue/composition-api";
+import { useMousePosition } from 'vue-use-web';
+
+export default {
+  setup() {
+    const { x, y } = useMousePosition();
+
+    return { x, y };
+  }
+};
+</script>
+```
+
+TODO: EXAMPLE

--- a/src/MousePosition.ts
+++ b/src/MousePosition.ts
@@ -1,0 +1,25 @@
+import { reactive, toRefs, onMounted, onUnmounted } from '@vue/composition-api';
+
+export function useMousePosition() {
+  const state = reactive({
+    x: 0,
+    y: 0
+  });
+
+  function handler(e: MouseEvent) {
+    state.x = e.clientX;
+    state.y = e.clientY;
+  }
+
+  onMounted(() => {
+    window.addEventListener('mousemove', handler, false);
+  });
+
+  onUnmounted(() => {
+    window.removeEventListener('mousemove', handler, false);
+  });
+
+  return {
+    ...toRefs(state)
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,4 @@ export * from './WindowScrollPosition';
 export * from './WindowSize';
 export * from './IntersectionObserver';
 export * from './FullScreen';
+export * from './MousePosition';


### PR DESCRIPTION
Adds the classic mouse position composition function that started it all :)

```vue
<template>
  <div>x: {{ x }} y: {{ y }}</div>
</template>

<script>
import { useMousePosition } from "vue-use-web";

export default {
  setup() {
    const { x, y } = useMousePosition();

    return { x, y };
  }
};
</script>
```