### PR TITLE
Typo fixed on useWindowSize documentation

### DIFF
--- a/docs/guide/window-size.md
+++ b/docs/guide/window-size.md
@@ -18,7 +18,7 @@ const { width, height } = useWindowSize();
 | height | `Number` | The client window height in pixels. |
 
 :::tip Note!
-By default the updates the state are throttled by 100ms to keep things snappy but you can configure that.
+By default the updates to the state are throttled by 100ms to keep things snappy but you can configure that.
 :::
 
 ## Config


### PR DESCRIPTION
Keep up the awesome work in this repo. It's an amazing idea and I can't wait for Vue 3 to be fully released so I can use this properly. For now, I'll help find typos. :)