### PR TITLE
Loosen typing in useEventListener

### DIFF
--- a/src/EventListener.ts
+++ b/src/EventListener.ts
@@ -1,20 +1,20 @@
 import { onMounted, onBeforeUnmount, Ref, isRef } from '@vue/composition-api';
 
-export function useEventListener<T extends EventTarget>(
+export function useEventListener<T extends EventTarget, E extends Event>(
   target: T | Ref<T>,
   type: string,
-  handler: EventListener,
+  handler: (this: T, evt: E) => void,
   options?: AddEventListenerOptions
 ) {
   onMounted(() => {
     const t = isRef(target) ? target.value : target;
 
-    t.addEventListener(type, handler, options);
+    t.addEventListener(type, handler as (evt: Event) => void, options);
   });
 
   onBeforeUnmount(() => {
     const t = isRef(target) ? target.value : target;
 
-    t.removeEventListener(type, handler, options);
+    t.removeEventListener(type, handler as (evt: Event) => void, options);
   });
 }


### PR DESCRIPTION
Hi there 🙂 👋 

When using your awesome library, I ran into a bit of an annoying edge case: using specific event types in event listeners.

By default, TypeScript will infer the type of event that's passed into the parameter of the handler function based on the target and event given, for example when using `mousedown` the type of event will be MouseEvent:

```javascript
window.addEventListener('mousedown', (event: MouseEvent) => console.log(event.pageX));
```

However, when using `useEventListener`, this typing is not inferred from the target / type. In the following example:

```javascript
useEventListener(window, 'mousedown', (event: MouseEvent) => console.log(event.pageX));
```

TypeScript will complain that MouseEvent can't be used in this handler:

```
Argument of type '(event: MouseEvent) => void' is not assignable to parameter of type 'EventListener'.
  Types of parameters 'event' and 'evt' are incompatible.
    Type 'Event' is missing the following properties from type 'MouseEvent': altKey, button, buttons, clientX, and 20 more.
```

(When using the regular Event type here, `event.pageX` doesn't exist according to TS)

---

There are three ways to fix this:

1. Don't use `useEventListener` and instead use the native `.addEventListener()`
2. Try to recreate the full TypeScript mapping and lookup tables for all combinations of events and types
3. Loosen the typing of `useEventListener` a notch so you can override the event type

Number 1 is obviously not a real solution here, 2 is _very_ overkill IMO, so I opted to go with number 3.

---

This PR allows you to pass another event type when using `useEventListener`, allowing you to properly use MouseEvents, KeyboardEvents, etc.