### PR TITLE
Rename onScroll -> onResize

### DIFF
--- a/src/WindowSize.ts
+++ b/src/WindowSize.ts
@@ -14,17 +14,17 @@ export function useWindowSize(options: WindowSizeOptions = { throttleMs: 100 }) 
     height.value = window.innerHeight;
   }
 
-  const onScroll = throttle(options.throttleMs, setSize);
+  const onResize = throttle(options.throttleMs, setSize);
   onBeforeMount(() => {
     setSize();
   });
 
   onMounted(() => {
-    window.addEventListener('resize', onScroll, { passive: true });
+    window.addEventListener('resize', onResize, { passive: true });
   });
 
   onUnmounted(() => {
-    window.removeEventListener('resize', onScroll);
+    window.removeEventListener('resize', onResize);
   });
 
   return {


### PR DESCRIPTION
I'm pretty sure the name `onScroll` came from copying https://github.com/logaretm/vue-use-web/blob/master/src/WindowScrollPosition.ts and forgetting to rename `onScroll` to something that matches the use case here. I renamed it to `onResize`, as that's when the handler is called 🙂 